### PR TITLE
Fix typo in exceptions.md

### DIFF
--- a/src/exceptions.md
+++ b/src/exceptions.md
@@ -55,7 +55,7 @@ Now we need to populate this section in our Rust program:
 #![feature(asm)]
 
 mod exception {
-    pub fn handler() {
+    pub fn handler() -> ! {
         unsafe {
             asm!("bkpt");
         }


### PR DESCRIPTION
Add a missing `-> !` to the exception handler.
