### PR TITLE
Add missing "eh_personality" language item in code and documentation

### DIFF
--- a/src/first/build.md
+++ b/src/first/build.md
@@ -73,7 +73,7 @@ mod lang_items {
     extern fn panic_fmt() {}
 
     #[lang = "eh_personality"]
-    pub extern fn rust_eh_personality() {}
+    extern fn rust_eh_personality() {}
 }
 ```
 

--- a/src/first/build.md
+++ b/src/first/build.md
@@ -65,12 +65,15 @@ mod vector_table {
     static RESET: fn() -> ! = ::start;
 }
 
-// Finally, we need to define the panic_fmt "lang item", which is just a function. This specifies
-// what the program should do when a `panic!` occurs. Our program won't panic, so we can leave the
-// function body empty for now.
+// Finally, we need to define the panic_fmt and eh_personality "lang item"s, which are just
+// functions. This specifies what the program should do when a `panic!` occurs. Our program won't
+// panic, so we can leave the function bodies empty for now.
 mod lang_items {
     #[lang = "panic_fmt"]
     extern fn panic_fmt() {}
+
+    #[lang = "eh_personality"]
+    pub extern fn rust_eh_personality() {}
 }
 ```
 
@@ -257,7 +260,7 @@ $ arm-none-eabi-readelf -h target/cortex-m3/debug/app
 
 ```
 ELF Header:
-  Magic:   7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00 
+  Magic:   7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00
   Class:                             ELF32
   Data:                              2's complement, little endian
   Version:                           1 (current)

--- a/src/first/main.rs
+++ b/src/first/main.rs
@@ -30,10 +30,13 @@ mod vector_table {
     static RESET: fn() -> ! = ::start;
 }
 
-// Finally, we need to define the panic_fmt "lang item", which is just a function. This specifies
-// what the program should do when a `panic!` occurs. Our program won't panic, so we can leave the
-// function body empty for now.
+// Finally, we need to define the panic_fmt and eh_personality "lang item"s, which are just
+// functions. This specifies what the program should do when a `panic!` occurs. Our program won't
+// panic, so we can leave the function bodies empty for now.
 mod lang_items {
     #[lang = "panic_fmt"]
     extern fn panic_fmt() {}
+
+    #[lang = "eh_personality"]
+    pub extern fn rust_eh_personality() {}
 }

--- a/src/first/main.rs
+++ b/src/first/main.rs
@@ -38,5 +38,5 @@ mod lang_items {
     extern fn panic_fmt() {}
 
     #[lang = "eh_personality"]
-    pub extern fn rust_eh_personality() {}
+    extern fn rust_eh_personality() {}
 }


### PR DESCRIPTION
Currently the build instructions fail without "eh_personality".

``` bash
➜  Git cargo new --bin frdm-app && cd $_
     Created binary (application) `frdm-app` project
➜  frdm-app git:(master) ✗ cp ../copper/src/first/layout.ld .
➜  frdm-app git:(master) ✗ cp ../copper/src/first/cortex-m3.json . 
➜  frdm-app git:(master) ✗ cp ../copper/src/first/main.rs ./src
➜  frdm-app git:(master) ✗ xargo build --target cortex-m3
   Compiling sysroot for cortex-m3
   Compiling core v0.0.0 (file:///Users/jamesmunns/.multirust/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore)
   Compiling rand v0.0.0 (file:///Users/jamesmunns/.multirust/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/src/librand)
   Compiling rustc_unicode v0.0.0 (file:///Users/jamesmunns/.multirust/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/src/librustc_unicode)
   Compiling alloc v0.0.0 (file:///Users/jamesmunns/.multirust/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/src/liballoc)
   Compiling collections v0.0.0 (file:///Users/jamesmunns/.multirust/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcollections)
    Finished release [optimized] target(s) in 16.77 secs
   Compiling frdm-app v0.1.0 (file:///Users/jamesmunns/Git/frdm-app)
error: language item required, but not found: `eh_personality`

error: aborting due to previous error

error: Could not compile `frdm-app`.

To learn more, run the command again with --verbose.
error: `cargo` process didn't exit successfully
```

After this change:

``` bash
➜  frdm-app git:(master) ✗ xargo build --target cortex-m3
   Compiling frdm-app v0.1.0 (file:///Users/jamesmunns/Git/frdm-app)
warning: unused variable: `y`, #[warn(unused_variables)] on by default
  --> src/main.rs:21:9
   |
21 |     let y = x;
   |         ^

warning: static item is never used: `RESET`, #[warn(dead_code)] on by default
  --> src/main.rs:30:5
   |
30 |     static RESET: fn() -> ! = ::start;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    Finished debug [unoptimized + debuginfo] target(s) in 0.10 secs
```
